### PR TITLE
Auth session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ target/
 #pycharm
 .idea/*
 
+#vscode
+.vscode/*
 
 #Ipython Notebook
 .ipynb_checkpoints

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ ophyd
 pytest >=3.9
 sphinx
 suitcase-utils[test_fixtures] >=0.1.0rc2
+mongomock
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 matplotlib

--- a/suitcase/mongo_normalized/__init__.py
+++ b/suitcase/mongo_normalized/__init__.py
@@ -73,7 +73,7 @@ class Serializer(event_model.DocumentRouter):
             [('time', pymongo.DESCENDING), ('scan_id', pymongo.DESCENDING)],
             unique=False, background=True)
         self._run_start_collection.create_index([("$**", "text")])
-        self._run_start_collection.create_index('auth_session', unique=False)
+        self._run_start_collection.create_index('data_session', unique=False)
         self._run_stop_collection.create_index('run_start', unique=True)
         self._run_stop_collection.create_index('uid', unique=True)
         self._run_stop_collection.create_index(

--- a/suitcase/mongo_normalized/__init__.py
+++ b/suitcase/mongo_normalized/__init__.py
@@ -73,6 +73,7 @@ class Serializer(event_model.DocumentRouter):
             [('time', pymongo.DESCENDING), ('scan_id', pymongo.DESCENDING)],
             unique=False, background=True)
         self._run_start_collection.create_index([("$**", "text")])
+        self._run_start_collection.create_index('auth_session', unique=False)
         self._run_stop_collection.create_index('run_start', unique=True)
         self._run_stop_collection.create_index('uid', unique=True)
         self._run_stop_collection.create_index(

--- a/suitcase/mongo_normalized/tests/fixtures.py
+++ b/suitcase/mongo_normalized/tests/fixtures.py
@@ -1,7 +1,7 @@
 # This separate fixtures module allows external libraries (e.g.
 # intake-bluesky-mongo) to import and reuse this fixtures without importing
 # *all* the fixtures used in conftest and the dependencies that they carry.
-import pymongo
+import mongomock
 import pytest
 import uuid
 
@@ -11,7 +11,7 @@ def db_factory(request):
     def inner():
         database_name = f'test-{str(uuid.uuid4())}'
         uri = 'mongodb://localhost:27017/'
-        client = pymongo.MongoClient(uri)
+        client = mongomock.MongoClient(uri)
 
         def drop():
             client.drop_database(database_name)

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -85,3 +85,46 @@ def test_validation_error(db_factory, example_data):
     serializer = Serializer(metadatastore_db, asset_registry_db)
     with pytest.raises(ValidationError):
         assert serializer.update('start', {})
+
+def test_index_creation(db_factory):
+    db = db_factory()
+    print(type(db))
+    metadatastore_db = db_factory()
+    asset_registry_db = db_factory()
+    Serializer(metadatastore_db, asset_registry_db)
+
+    indexes = asset_registry_db.resource.index_information()
+    assert len(indexes.keys()) == 3
+    assert indexes['uid_1']['unique']
+    assert indexes['resource_id_1']
+    
+    indexes = asset_registry_db.datum.index_information()
+    assert len(indexes.keys()) == 3
+    assert indexes['datum_id_1']['unique']
+    assert indexes['resource_1']
+
+    indexes = metadatastore_db.run_start.index_information()
+    assert len(indexes.keys()) == 5
+    assert indexes['uid_1']['unique']
+    assert indexes['time_-1_scan_id_-1']
+    assert indexes['$**_text']
+    assert indexes['auth_session_1']
+
+    indexes = metadatastore_db.run_stop.index_information()
+    assert len(indexes.keys()) == 5
+    assert indexes['uid_1']['unique']
+    assert indexes['run_start_1']['unique']
+    assert indexes['time_-1']
+    assert indexes['$**_text']
+
+    indexes = metadatastore_db.event_descriptor.index_information()
+    assert len(indexes.keys()) == 5
+    assert indexes['uid_1']['unique']
+    assert indexes['run_start_-1_time_-1']
+    assert indexes['time_-1']
+    assert indexes['$**_text']
+
+    indexes = metadatastore_db.event.index_information()
+    assert len(indexes.keys()) == 3
+    assert indexes['uid_1']['unique']
+    assert indexes['descriptor_-1_time_1']

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -98,7 +98,7 @@ def test_index_creation(db_factory):
     assert len(indexes.keys()) == 3
     assert indexes['uid_1']['unique']
     assert indexes['resource_id_1']
-    
+
     indexes = asset_registry_db.datum.index_information()
     assert len(indexes.keys()) == 3
     assert indexes['datum_id_1']['unique']

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -109,7 +109,7 @@ def test_index_creation(db_factory):
     assert indexes['uid_1']['unique']
     assert indexes['time_-1_scan_id_-1']
     assert indexes['$**_text']
-    assert indexes['auth_session_1']
+    assert indexes['data_session_1']
 
     indexes = metadatastore_db.run_stop.index_information()
     assert len(indexes.keys()) == 5

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -86,6 +86,7 @@ def test_validation_error(db_factory, example_data):
     with pytest.raises(ValidationError):
         assert serializer.update('start', {})
 
+
 def test_index_creation(db_factory):
     db = db_factory()
     print(type(db))


### PR DESCRIPTION
Adds an index to the start document of mongo_normalized to index the "auth_session" field. This field is introduced in a PR in event-model (https://github.com/bluesky/event-model/pull/196).

This PR indexes that field for fast searching. I also added a test function to validate that indexes are getting created. Possibly extraneous, but oh well.

Finally, I added mongomock to the mongo_normalized fixtures. This makes the tests run several orders of magnitude faster.

I think we should do both fixes to mongo_embedded, but I'm not really familiar with that structure. Also, on a first quick pass, mongomock fails to run there...something to do with threading workers? Again, not familiar. But I'd really like this fix merged into mongo_normalized soon for my splash project.