### PR TITLE
Add data_groups index

### DIFF
--- a/suitcase/mongo_normalized/__init__.py
+++ b/suitcase/mongo_normalized/__init__.py
@@ -74,6 +74,7 @@ class Serializer(event_model.DocumentRouter):
             unique=False, background=True)
         self._run_start_collection.create_index([("$**", "text")])
         self._run_start_collection.create_index('data_session', unique=False)
+        self._run_start_collection.create_index('data_groups', unique=False)
         self._run_stop_collection.create_index('run_start', unique=True)
         self._run_stop_collection.create_index('uid', unique=True)
         self._run_stop_collection.create_index(

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -105,11 +105,12 @@ def test_index_creation(db_factory):
     assert indexes['resource_1']
 
     indexes = metadatastore_db.run_start.index_information()
-    assert len(indexes.keys()) == 5
+    assert len(indexes.keys()) == 6
     assert indexes['uid_1']['unique']
     assert indexes['time_-1_scan_id_-1']
     assert indexes['$**_text']
     assert indexes['data_session_1']
+    assert indexes['data_groups_1']
 
     indexes = metadatastore_db.run_stop.index_information()
     assert len(indexes.keys()) == 5


### PR DESCRIPTION
A follow up. Based on what actually got merged in https://github.com/bluesky/event-model/pull/196, another field in the run_start document should have an index, `data_groups`.