### PR TITLE
Duplicate handling followup

### DIFF
--- a/suitcase/mongo_normalized/__init__.py
+++ b/suitcase/mongo_normalized/__init__.py
@@ -67,7 +67,7 @@ class Serializer(event_model.DocumentRouter):
 
         If the index already exists, this has no effect.
         """
-        self._resource_collection.create_index('uid', unique=True)
+        self._resource_collection.create_index('uid')
         self._resource_collection.create_index('resource_id')  # legacy
         # TODO: Migrate all Resources to have a RunStart UID, and then make a
         # unique index on:

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -95,7 +95,7 @@ def test_index_creation(db_factory):
 
     indexes = asset_registry_db.resource.index_information()
     assert len(indexes.keys()) == 3
-    assert indexes['uid_1']['unique']
+    assert not indexes['uid_1'].get('unique')
     assert indexes['resource_id_1']
 
     indexes = asset_registry_db.datum.index_information()

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -5,8 +5,7 @@ import copy
 import pytest
 from event_model import sanitize_doc
 from jsonschema import ValidationError
-from pymongo.errors import DuplicateKeyError
-from suitcase.mongo_normalized import Serializer
+from suitcase.mongo_normalized import DuplicateUniqueID, Serializer
 
 
 def test_export(db_factory, example_data):
@@ -32,7 +31,7 @@ def test_duplicates(db_factory, example_data):
     # Modify a document, check that inserting a document with uid,
     # but different content raises.
     documents[0][1]['new_key'] = 'new_value'
-    with pytest.raises(DuplicateKeyError):
+    with pytest.raises(DuplicateUniqueID):
         for item in documents:
             serializer(*item)
 


### PR DESCRIPTION
Follow-up to #34 to ensure that existing databases remain compatible with old installations of databroker (v0) and with current suitcase-mongo. See full multi-line commit messages for details.