### PR TITLE
add scan_id index

### DIFF
--- a/suitcase/mongo_normalized/__init__.py
+++ b/suitcase/mongo_normalized/__init__.py
@@ -86,6 +86,7 @@ class Serializer(event_model.DocumentRouter):
         self._datum_collection.create_index('datum_id', unique=True)
         self._datum_collection.create_index('resource')
         self._run_start_collection.create_index('uid', unique=True)
+        self._run_start_collection.create_index('scan_id', unique=False)
         self._run_start_collection.create_index(
             [('time', pymongo.DESCENDING), ('scan_id', pymongo.DESCENDING)],
             unique=False, background=True)


### PR DESCRIPTION
scan_id lookups were taking a long time without this index.
```
In [27]: %time db[305062]
CPU times: user 92 ms, sys: 2.27 ms, total: 94.3 ms
Wall time: 6.38 s
Out[27]: <databroker._core.Header at 0x7fdb6f8e1a00>
```