### PR TITLE
Change index creation time from being on connect to on create

### DIFF
--- a/suitcase/mongo_normalized/__init__.py
+++ b/suitcase/mongo_normalized/__init__.py
@@ -83,9 +83,8 @@ class Serializer(event_model.DocumentRouter):
         self._asset_registry_db = assets_db
         self._ignore_duplicates = ignore_duplicates
         self._resource_uid_unique = resource_uid_unique
-        self._create_indexes()
 
-    def _create_indexes(self):
+    def create_indexes(self):
         """
         Create indexes on the various collections.
 

--- a/suitcase/mongo_normalized/tests/conftest.py
+++ b/suitcase/mongo_normalized/tests/conftest.py
@@ -2,4 +2,4 @@ from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
 from suitcase.utils.tests.conftest import (  # noqa
     example_data, generate_data, plan_type, detector_list, event_type)
-from .fixtures import db_factory  # noqa
+from .fixtures import db_factory, db_factory_no_indexes  # noqa

--- a/suitcase/mongo_normalized/tests/fixtures.py
+++ b/suitcase/mongo_normalized/tests/fixtures.py
@@ -22,6 +22,7 @@ def db_factory_no_indexes(request):
         return db
     return inner
 
+
 @pytest.fixture()
 def db_factory(request):
     def inner():

--- a/suitcase/mongo_normalized/tests/fixtures.py
+++ b/suitcase/mongo_normalized/tests/fixtures.py
@@ -8,6 +8,21 @@ from suitcase.mongo_normalized import Serializer
 
 
 @pytest.fixture()
+def db_factory_no_indexes(request):
+    def inner():
+        database_name = f'test-{str(uuid.uuid4())}'
+        uri = 'mongodb://localhost:27017/'
+        client = mongomock.MongoClient(uri)
+        db = client[database_name]
+
+        def drop():
+            client.drop_database(database_name)
+
+        request.addfinalizer(drop)
+        return db
+    return inner
+
+@pytest.fixture()
 def db_factory(request):
     def inner():
         database_name = f'test-{str(uuid.uuid4())}'

--- a/suitcase/mongo_normalized/tests/fixtures.py
+++ b/suitcase/mongo_normalized/tests/fixtures.py
@@ -4,6 +4,8 @@
 import mongomock
 import pytest
 import uuid
+from suitcase.mongo_normalized import Serializer
+
 
 
 @pytest.fixture()
@@ -12,10 +14,12 @@ def db_factory(request):
         database_name = f'test-{str(uuid.uuid4())}'
         uri = 'mongodb://localhost:27017/'
         client = mongomock.MongoClient(uri)
-
         def drop():
             client.drop_database(database_name)
 
         request.addfinalizer(drop)
-        return client[database_name]
+        db = client[database_name]
+        serializer = Serializer(db, db)
+        serializer.create_indexes()
+        return db
     return inner

--- a/suitcase/mongo_normalized/tests/fixtures.py
+++ b/suitcase/mongo_normalized/tests/fixtures.py
@@ -7,19 +7,19 @@ import uuid
 from suitcase.mongo_normalized import Serializer
 
 
-
 @pytest.fixture()
 def db_factory(request):
     def inner():
         database_name = f'test-{str(uuid.uuid4())}'
         uri = 'mongodb://localhost:27017/'
         client = mongomock.MongoClient(uri)
+        db = client[database_name]
+        serializer = Serializer(db, db)
+        serializer.create_indexes()
+
         def drop():
             client.drop_database(database_name)
 
         request.addfinalizer(drop)
-        db = client[database_name]
-        serializer = Serializer(db, db)
-        serializer.create_indexes()
         return db
     return inner

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -23,6 +23,7 @@ def test_duplicates(db_factory, example_data):
     metadatastore_db = db_factory()
     asset_registry_db = db_factory()
     serializer = Serializer(metadatastore_db, asset_registry_db)
+    
     for item in documents:
         serializer(*item)
     for item in documents:

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -23,7 +23,7 @@ def test_duplicates(db_factory, example_data):
     metadatastore_db = db_factory()
     asset_registry_db = db_factory()
     serializer = Serializer(metadatastore_db, asset_registry_db)
-    
+
     for item in documents:
         serializer(*item)
     for item in documents:

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -205,12 +205,10 @@ def test_index_creation(db_factory):
     assert indexes["descriptor_-1_time_1"]
 
 
-def test_resource_uid_unique(db_factory):
-    db = db_factory()
-    print(type(db))
-    metadatastore_db = db_factory()
-    asset_registry_db = db_factory()
-    Serializer(metadatastore_db, asset_registry_db, resource_uid_unique=True)
+def test_resource_uid_unique(db_factory_no_indexes):
+    metadatastore_db = db_factory_no_indexes()
+    asset_registry_db = db_factory_no_indexes()
+    Serializer(metadatastore_db, asset_registry_db, resource_uid_unique=True).create_indexes()
 
     indexes = asset_registry_db.resource.index_information()
     assert indexes["uid_1"].get("unique")


### PR DESCRIPTION
Users at NSLS-II have reported that connections handled through suitcase mongo can be exceptionally slow when searching for data. Part of this might be from superfluous use of `pymongo.serializer` in certain methods like `update_metadata`, but we've identified that another cause is the client's attempt to create indexes upon each connection.

This PR is an attempt to address #37

Tasks required
- [x] Make `create_index` a public method
- [x] Remove that method from `_init_` so it does not run every time
- [ ] Update docs to inform users that they need to create indexes manually when setting up or migrating a mongo tiled database.
- [x] Pass all tests