### PR TITLE
Bump python versions in CI tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
         - 27017:27017
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
         - 27017:27017
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.9, 3.10, 3.11]
       fail-fast: false
     steps:
 

--- a/suitcase/mongo_normalized/tests/tests.py
+++ b/suitcase/mongo_normalized/tests/tests.py
@@ -168,12 +168,21 @@ def test_index_creation(db_factory):
     assert indexes["resource_1"]
 
     indexes = metadatastore_db.run_start.index_information()
-    assert len(indexes.keys()) == 6
+    assert len(indexes.keys()) == 10
+    for index_name in [
+        '_id_',
+        'uid_1',
+        'scan_id_1',
+        'scan_id_-1__id_-1',
+        'time_1__id_-1',
+        'time_-1__id_-1',
+        'time_-1_scan_id_-1',
+        '$**_text',
+        'data_session_1',
+        'data_groups_1',
+    ]:
+        assert index_name in indexes
     assert indexes["uid_1"]["unique"]
-    assert indexes["time_-1_scan_id_-1"]
-    assert indexes["$**_text"]
-    assert indexes["data_session_1"]
-    assert indexes["data_groups_1"]
 
     indexes = metadatastore_db.run_stop.index_information()
     assert len(indexes.keys()) == 5


### PR DESCRIPTION
3.6 is end of life, 3.7 might be and 3.8 wants to be.
So this removes those and replaces them with 3.9, 3.10 & 3.11